### PR TITLE
Remove local secrets from repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment settings for deployment scripts
+# Copy this file to `.env.local` and customize the values. Do NOT commit `.env.local`.
+
+# SSH user for the remote server
+REMOTE_USER=""
+# Hostname or IP of the remote server
+REMOTE_HOST=""
+
+# Optional: production PIN will be set directly on the server's .env file
+#APP_PIN_PRODUCTION=""

--- a/.env.local
+++ b/.env.local
@@ -1,8 +1,0 @@
-# Local environment settings for deployment scripts
-# This file should be in .gitignore
-
-REMOTE_USER="shodanadmin"
-REMOTE_HOST="shodan1.nclgisa.org"
-# Your production PIN - this is used by remote_server_setup.sh to write into the .env on the server
-# APP_PIN_PRODUCTION="908070" 
-# ^ We will inject this directly into the server's .env file via the setup script instead of reading it here. 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 
 # Environment variables
 .env
-.env.local # Local environment configurations
+# Local environment configurations
+.env.local
 
 # Uploads directory (for user-uploaded CSVs)
 uploads/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The application is designed with simplicity and mobile-friendliness in mind, all
 
 *   **PIN**: The application access PIN is configured via the `DRAWING_APP_PIN` environment variable on the server. For local development without this variable set, it defaults to `123456`.
 *   **Flask Secret Key**: The `FLASK_SECRET_KEY` for session management must be set as an environment variable for production deployments.
-*   **Data Files**: Registrant CSV files, the live SQLite database (`drawing.db`), and environment files (`.env`, `.env.local`) are excluded from the Git repository via `.gitignore` to protect sensitive information.
+*   **Data Files**: Registrant CSV files, the live SQLite database (`drawing.db`), and environment files (`.env`, `.env.local`) are excluded from the Git repository via `.gitignore` to protect sensitive information. A template `.env.example` is provided for creating your own `.env.local` file.
 
 ---
 

--- a/package_and_upload.sh
+++ b/package_and_upload.sh
@@ -10,9 +10,11 @@ ARCHIVE_NAME="${APP_NAME}.tar.gz"
 if [ -f .env.local ]; then
     source .env.local
 fi
-REMOTE_USER="${REMOTE_USER:-shodanadmin}" # Default if not set in .env.local
-REMOTE_HOST="${REMOTE_HOST:-shodan1.nclgisa.org}" # Default if not set in .env.local
-# PRODUCTION_APP_PIN="908070" # REMOVED - This will be set manually on the server's .env file
+
+# Require REMOTE_USER and REMOTE_HOST to be provided via environment
+# variables or a local .env.local file. No hard-coded defaults.
+: "${REMOTE_USER:?REMOTE_USER not set. Define it in the environment or .env.local}"
+: "${REMOTE_HOST:?REMOTE_HOST not set. Define it in the environment or .env.local}"
 
 REMOTE_TEMP_UPLOAD_DIR="/tmp"
 PROJECT_DIR_ON_SERVER_BASE="/srv"
@@ -95,7 +97,7 @@ FLASK_APP=app.py
 FLASK_ENV=production
 FLASK_SECRET_KEY=${FLASK_SECRET_KEY_VALUE}
 # IMPORTANT: Set your production PIN here manually after script runs!
-DRAWING_APP_PIN="# YOUR_PRODUCTION_PIN_HERE (e.g., 908070)"
+DRAWING_APP_PIN="# YOUR_PRODUCTION_PIN_HERE (e.g., 000000)"
 EOTENV
 chown "${REMOTE_USER_ON_SERVER}:${REMOTE_USER_ON_SERVER}" "${ENV_FILE_PATH}" && chmod 600 "${ENV_FILE_PATH}"
 echo "IMPORTANT: .env file created. Please edit ${ENV_FILE_PATH} and set DRAWING_APP_PIN to your production PIN."
@@ -158,7 +160,7 @@ cat << EOF > "${REMOTE_APP_UPDATE_SCRIPT_NAME}"
 
 APP_NAME="nclgisa_drawing_app"
 ARCHIVE_NAME="${APP_NAME}.tar.gz"
-REMOTE_USER_ON_SERVER="shodanadmin" # Needs to match user in systemd service
+REMOTE_USER_ON_SERVER="${REMOTE_USER}" # Needs to match user in systemd service
 PROJECT_HOME_DIR_ON_SERVER="/srv"
 PROJECT_DIR_ON_SERVER="${PROJECT_HOME_DIR_ON_SERVER}/${APP_NAME}"
 


### PR DESCRIPTION
## Summary
- delete `.env.local` from version control
- add `.env.example` and document using it
- require `REMOTE_USER`/`REMOTE_HOST` in `package_and_upload.sh`
- fix gitignore rule for `.env.local`

## Testing
- `python -m py_compile $(git ls-files '*.py')`