### PR TITLE
Fix FLASK_ENV handling for production

### DIFF
--- a/start_app.sh
+++ b/start_app.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-# Ensure Flask environment variables are set (optional, but good practice)
+# This script is intended mainly for local development using `flask run`.
+# Production deployments usually run the app via Gunicorn and systemd.
+# In those cases FLASK_ENV should remain unset or be set to `production`.
+
+# Set the target Flask app
 export FLASK_APP=app.py
-export FLASK_ENV=development # Enables debug mode among other things
+
+# Enable development conveniences only if FLASK_ENV isn't already defined.
+# Developers benefit from auto-reload and debug features by leaving this unset.
+if [ -z "$FLASK_ENV" ]; then
+    export FLASK_ENV=development
+fi
 
 # Initialize the database (creates tables and imports initial data if DB is empty)
 flask init-db
@@ -11,5 +20,9 @@ flask init-db
 # The app.py itself is already configured to run on port 8080 with debug=True
 flask run --host=0.0.0.0 --port=8080
 
+# For production deployments use a WSGI server like Gunicorn instead of
+# running this script. The setup scripts in this project create a systemd
+# service that starts Gunicorn with FLASK_ENV=production.
+
 # Alternative using python directly if you prefer (app.py already sets port and debug):
-# python app.py 
+# python app.py


### PR DESCRIPTION
## Summary
- make `start_app.sh` detect production usage instead of forcing `FLASK_ENV=development`
- explain the difference between development and production settings

## Testing
- `bash -n start_app.sh`
- `python3 -m py_compile app.py`
