### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 schmug
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The application is designed with simplicity and mobile-friendliness in mind, all
 *   **Flask Secret Key**: The `FLASK_SECRET_KEY` for session management must be set as an environment variable for production deployments.
 *   **Data Files**: Registrant CSV files, the live SQLite database (`drawing.db`), and environment files (`.env`, `.env.local`) are excluded from the Git repository via `.gitignore` to protect sensitive information. A template `.env.example` is provided for creating your own `.env.local` file.
 
+## License
+
+This project is released under the [MIT License](LICENSE).
+
 ---
 
 This README provides a functional overview. For detailed setup, deployment, and code structure, refer to the project files and associated deployment scripts. 


### PR DESCRIPTION
## Summary
- add MIT license
- reference the license in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*